### PR TITLE
Fix with-current-buffer error

### DIFF
--- a/webkit-katex-render.el
+++ b/webkit-katex-render.el
@@ -175,8 +175,9 @@
 
 (defun webkit-katex-render--get-xwidget ()
   "Return Xwidget instance."
+  (if (get-buffer webkit-katex-render--buffer-name)
   (with-current-buffer webkit-katex-render--buffer-name
-    (xwidget-at 1)))
+    (xwidget-at 1))))
 
 (defun webkit-katex-render--execute-script (script &optional fn)
   "Execute SCRIPT in embedded Xwidget and run optional callback FN."


### PR DESCRIPTION
Before creating any " *webkit-katex-render*" buffer, there is no buffer named after " *webkit-katex-render*". The 'with-current-buffer' function seems to throw error only when ' f ' key is pressed in insert mode of spacemacs with evil-escape mode on. The error doesn't happen when evil-escape mode is off. After adding code to check whether " *webkit-katex-render*" buffer exists, the error disappeared.